### PR TITLE
Fix code scanning alert no. 226: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/csharp/ql/test/query-tests/Security Features/CWE-011/bad2/Web.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-011/bad2/Web.config
@@ -3,7 +3,6 @@
   <system.web>
     <compilation
       defaultLanguage="c#"
-      debug="true"
     />
   </system.web>
 </configuration>


### PR DESCRIPTION
Fixes [https://github.com/akaday/codeql/security/code-scanning/226](https://github.com/akaday/codeql/security/code-scanning/226)

To fix the problem, we need to set the `debug` attribute to `false` or remove it entirely from the `Web.config` file. This change will ensure that the application does not expose sensitive debugging information and will improve performance by disabling debugging features.

The best way to fix the problem without changing existing functionality is to remove the `debug` attribute from the `<compilation>` element in the `Web.config` file. This will prevent the application from being built in debug mode, thus mitigating the security risk and performance issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
