### PR TITLE
Fix code scanning alert no. 225: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/csharp/ql/test/query-tests/Security Features/CWE-011/bad1/Web.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-011/bad1/Web.config
@@ -3,7 +3,6 @@
   <system.web>
     <compilation
       defaultLanguage="c#"
-      debug="true"
     />
   </system.web>
 </configuration>


### PR DESCRIPTION
Fixes [https://github.com/akaday/codeql/security/code-scanning/225](https://github.com/akaday/codeql/security/code-scanning/225)

To fix the problem, we need to ensure that the `debug` flag is not set to `true` in the `Web.config` file. The best way to fix this issue without changing existing functionality is to set the `debug` flag to `false` or remove it entirely from the `Web.config` file. This change should be made in the `csharp/ql/test/query-tests/Security Features/CWE-011/bad1/Web.config` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
