### PR TITLE
Fix code scanning alert no. 228: Page request validation is disabled

### DIFF
--- a/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetPagesValidateRequest/ASPNetPagesValidateRequestBad.config
+++ b/csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetPagesValidateRequest/ASPNetPagesValidateRequestBad.config
@@ -1,5 +1,5 @@
 <configuration>
   <system.web>
-    <pages validateRequest="false" />
+    <pages validateRequest="true" />
   </system.web>
 </configuration>


### PR DESCRIPTION
Fixes [https://github.com/akaday/codeql/security/code-scanning/228](https://github.com/akaday/codeql/security/code-scanning/228)

To fix the problem, we need to enable request validation by setting the `validateRequest` attribute to `true` in the `web.config` file. This change will ensure that the application is protected against common XSS attacks by validating the content of incoming requests.

The specific change involves modifying the `validateRequest` attribute in the `<pages>` element from `false` to `true`. This change should be made in the `csharp/ql/test/query-tests/Security Features/CWE-016/ASPNetPagesValidateRequest/ASPNetPagesValidateRequestBad.config` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
